### PR TITLE
refactor: rename Widget's input and resize handler

### DIFF
--- a/src/display/widget.c
+++ b/src/display/widget.c
@@ -152,8 +152,8 @@ void Widget_onParentResize(Widget *self, int new_parent_width, int new_parent_he
         return;
     }
 
-    if (self->ops && self->ops->handle_resize) {
-        self->ops->handle_resize(self, new_parent_width, new_parent_height);
+    if (self->ops && self->ops->on_resize) {
+        self->ops->on_resize(self, new_parent_width, new_parent_height);
     }
 
     // Propagate the resize event to children, passing the NEW size of THIS widget.
@@ -171,8 +171,8 @@ void Widget_HandleInput(Widget *self, EscapeSequence key, UTF8Char ch) {
         logError("Invalid widget.");
         return;
     }
-    if (self->ops && self->ops->handle_input) {
-        self->ops->handle_input(self, key, ch);
+    if (self->ops && self->ops->on_input) {
+        self->ops->on_input(self, key, ch);
     }
     for (int i=0; i<self->children_count; i++) {
         Widget *child = self->children[i];

--- a/src/display/widget.h
+++ b/src/display/widget.h
@@ -18,9 +18,9 @@ typedef struct {
     // Draws the widget onto a target canvas.
     void (*draw)(const struct _Widget *self, Canvas *target);
     // Handles input. Returns true if the input was consumed.
-    bool (*handle_input)(struct _Widget *self, EscapeSequence key, UTF8Char ch);
+    bool (*on_input)(struct _Widget *self, EscapeSequence key, UTF8Char ch);
     // Handles resize events
-    void (*handle_resize)(struct _Widget *self, int new_parent_width, int new_parent_height);
+    void (*on_resize)(struct _Widget *self, int new_parent_width, int new_parent_height);
     // Called (by App_SetFocus()) when the widget gains focus.
     void (*on_focus)(struct _Widget *self);
     // Called (by App_ClearFocus()) when the widget looses focus.

--- a/src/widgets/app.c
+++ b/src/widgets/app.c
@@ -22,8 +22,8 @@ static void app_handle_resize(Widget *self, int new_parent_width, int new_parent
 static WidgetOps app_ops = {
     .draw = NULL,
     .destroy = app_destroy,
-    .handle_resize = app_handle_resize,
-    .handle_input = NULL,
+    .on_resize = app_handle_resize,
+    .on_input = NULL,
 };
 
 void App_Init(int width, int height) {

--- a/src/widgets/bottombar.c
+++ b/src/widgets/bottombar.c
@@ -32,8 +32,8 @@ void bottombar_handle_resize(Widget *self, int new_parent_width, int new_parent_
 static WidgetOps bottombar_ops = {
     .draw = bottombar_draw,
     .destroy = bottombar_destroy,
-    .handle_resize = bottombar_handle_resize,
-    .handle_input = NULL,
+    .on_resize = bottombar_handle_resize,
+    .on_input = NULL,
 };
 
 Widget *BottomBar_Create(Widget *parent) {

--- a/src/widgets/editor.c
+++ b/src/widgets/editor.c
@@ -120,7 +120,7 @@ static void editor_scroll_down(EditorData *data) {
     data->first_line = data->first_line->next;
 }
 
-// widget->ops->handle_input() function
+// widget->ops->on_input() function
 static bool editor_handle_input(Widget *self, EscapeSequence key, UTF8Char ch) {
     (void)key;
     EditorData *data = (EditorData*)self->data;
@@ -183,7 +183,7 @@ static bool editor_handle_input(Widget *self, EscapeSequence key, UTF8Char ch) {
     return true;
 }
 
-// widget->ops->handle_resize() function
+// widget->ops->on_resize() function
 static void editor_handle_resize(Widget *self, int parent_w, int parent_h) {
     self->width = parent_w;
     self->height = parent_h - 1;
@@ -203,8 +203,8 @@ static void editor_on_blur(Widget *self) {
 static WidgetOps editor_ops = {
     .destroy = editor_Destroy,
     .draw = editor_draw,
-    .handle_input = editor_handle_input,
-    .handle_resize = editor_handle_resize,
+    .on_input = editor_handle_input,
+    .on_resize = editor_handle_resize,
     .on_focus = editor_on_focus,
     .on_blur = editor_on_blur,
 };

--- a/src/widgets/label.c
+++ b/src/widgets/label.c
@@ -32,7 +32,7 @@ static void label_destroy(Widget *self) {
 static WidgetOps label_ops = {
     .draw = label_draw,
     .destroy = label_destroy,
-    // .handle_input = NULL, // Ein Label reagiert nicht auf Input
+    // .on_input = NULL, // Ein Label reagiert nicht auf Input
 };
 
 // 4. Der "Konstruktor"


### PR DESCRIPTION
Closes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized internal widget event callback naming across the interface and all widgets for consistency. This aligns event wiring for input and resize events without altering behavior or performance. No user-facing changes.

- Chores
  - Updated related initializations and comments to match the new naming scheme. No functional impact and no action required for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->