### PR TITLE
Add early-exit guards to table lookup functions

### DIFF
--- a/src/common/table.c
+++ b/src/common/table.c
@@ -239,6 +239,9 @@ void Table_Delete(Table *table, const char *key) {
     if (!table) {
         logFatal("Invalid table in Table_Delete().");
     }
+    if (table->used == 0) {
+        return;
+    }
     if (!key) {
         logWarn("Table_Delete() is called with key == NULL.");
         return;

--- a/src/common/table.c
+++ b/src/common/table.c
@@ -220,6 +220,9 @@ void *Table_Get(const Table *table, const char *key) {
     if (!table) {
         logFatal("Invalid table in Table_Get().");
     }
+    if (table->used == 0) {
+        return NULL;
+    }
     if (!key) {
         logWarn("Table_Get() was called with key == NULL.");
         return NULL;
@@ -255,6 +258,9 @@ bool Table_Has(const Table *table, const char *key) {
     if (!table) {
         logFatal("Invalid table in Table_Has().");
     }
+    if (table->used == 0) {
+        return false;
+    }
     if (!key) {
         logWarn("Table_Has() was called with key == NULL.");
         return false;
@@ -266,6 +272,9 @@ bool Table_Has(const Table *table, const char *key) {
 bool Table_HasOwnership(const Table *table, const char *key) {
     if (!table) {
         logFatal("Invalid table in Table_HasOwnership().");
+    }
+    if (table->used == 0) {
+        return false;
     }
     if (!key) {
         logWarn("Table_HasOwnership() was called with key == NULL.");

--- a/tests/test_table.c
+++ b/tests/test_table.c
@@ -105,7 +105,13 @@ void test_edge_case(void) {
     }
 
     Table_Get(table, "key0");
-    
+    Table_Destroy(table);
+
+    // checks on empty table
+    table = Table_Create();
+    TEST_CHECK(!Table_Get(table, "key"));
+    TEST_CHECK(!Table_Has(table, "key"));
+    TEST_CHECK(!Table_HasOwnership(table, "key"));
     Table_Destroy(table);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Table operations now short-circuit on empty tables, avoiding unnecessary work and preventing incorrect lookups or deletions on empty instances.

* **Tests**
  * Expanded tests to cover behavior with empty table instances, validating lookups, existence checks, and destruction edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->